### PR TITLE
Install and use Clang-format-8 instead of Clang-format-7

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,8 @@ steps:
     sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends clang-format-8
+    ls
+    ls /usr/bin/clang*
     sudo ln -s clang-format-8 /usr/bin/clang-format
   displayName: Install clang-format
 - script: make clang-format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,6 @@ steps:
     sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends clang-format-8
-    ls
-    ls /usr/bin/clang*
     sudo ln -s clang-format-8 /usr/bin/clang-format
   displayName: Install clang-format
 - script: make clang-format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ steps:
   displayName: "Compile btl_bloomfilter"
 - script: |
     curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
+    sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends clang-format-8
     ls

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,8 @@ steps:
     curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
     sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
     sudo apt-get update
-    sudo apt-get install -y --no-install-recommends clang-format-7
-    sudo ln -s clang-format-7 /usr/bin/clang-format
+    sudo apt-get install -y --no-install-recommends clang-format-8
+    sudo ln -s clang-format-8 /usr/bin/clang-format
   displayName: Install clang-format
 - script: make clang-format
   displayName: Run clang-format


### PR DESCRIPTION
We decided to use version 8 in our azure CI as our current linuxbrew clang installation is also version 8.