### PR TITLE
BloomFilterTests.cpp: check for filter2 when loading instead of filter

### DIFF
--- a/Tests/Unit/BloomFilterTests.cpp
+++ b/Tests/Unit/BloomFilterTests.cpp
@@ -125,7 +125,7 @@ TEST_CASE("test fixture", "[BloomFilter]")
 
 		ntHashIterator queryIt(seq, numHashes, k);
 		while (queryIt != queryIt.end()) {
-			assert(filter.contains(*queryIt));
+			assert(filter2.contains(*queryIt));
 			++queryIt;
 		}
 


### PR DESCRIPTION
Bug fixed a line of code in BloomFilterTests.cpp