### PR TITLE
BloomFilterTests: use heap by allocating more memory

### DIFF
--- a/Tests/AdHoc/BloomFilterTests.cpp
+++ b/Tests/AdHoc/BloomFilterTests.cpp
@@ -44,7 +44,7 @@ main()
 	// memory usage from before
 	int memUsage = memory_usage();
 
-	size_t filterSize = 1000000;
+	size_t filterSize = 10000000;
 
 	const unsigned numHashes = 3;
 	const unsigned k = 4;


### PR DESCRIPTION
The test failed because it wasn't allocating memory on heap. Now it will on hpce704 so the test shouldn't fail